### PR TITLE
fix(deps): add missing node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"node-cron": "^2.0.3",
 		"save": "^2.4.0",
 		"sqlite3": "^5.0.2",
-		"winston": "^3.3.3"
+		"winston": "^3.3.3",
+		"node-fetch": "^2.6.0"
 	},
 	"devDependencies": {
 		"eslint": "^7.29.0",


### PR DESCRIPTION
## Summary

`node-fetch` is required by multiple files but missing from `package.json` dependencies:
- `commands/gif.js:6`
- `commands/movie.js`
- `scripts/holidays.js:4`
- `scripts/7d2d.js:4`

## Fix

Add `node-fetch@^2.6.0` to dependencies.

Fixes #13.