### PR TITLE
fix(deps): remove unused sqlite3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"jsdom": "^16.6.0",
 		"node-cron": "^2.0.3",
 		"save": "^2.4.0",
-		"sqlite3": "^5.0.2",
 		"winston": "^3.3.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

`package.json` line 18 declares `"sqlite3": "^5.0.2"` but **no source file in the repo requires it**. This native module requires compilation and is dead code.

## Fix

Remove `sqlite3` from dependencies.

Fixes #15.