### PR TITLE
fix(cron): pin cron schedules to America/New_York (closes #11)

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -86,22 +86,23 @@ client.on('ready', () => {
          updates7d2d(newUpdate);
       });
    }
-   cron.schedule(morning_cron, () => { 
+   const cronOpts = { timezone: 'America/New_York' };
+   cron.schedule(morning_cron, () => {
       todayHoliday(workingToday);
       fetch7d2dUpdates();
       console.log('MORNING CRON SUCCESS');
-   });
+   }, cronOpts);
    cron.schedule(evening_cron, () => {
       todayHoliday(workingToday);
       fetch7d2dUpdates();
       console.log('EVENING CRON SUCCESS');
-   });
+   }, cronOpts);
 
    // TEST CRON JOB: ONLY UNCOMMENT WHEN DEBUGGING AND KILL UPON FIRST EXECUTION
    if (process.argv[2] === 'debug' && process.argv[3] === 'cron') {
       cron.schedule('* * * * * *', () => {
          //...something to test here
-      }); 
+      }, cronOpts);
    }
 
 });


### PR DESCRIPTION
Closes #11.

## Summary

`node-cron` defaults to the process's local timezone. On a UTC host (most cloud / VPS setups), the morning_cron `"00 09 * * *"` actually fires at 04:00 ET in winter / 05:00 ET in summer rather than 09:00 ET. Hardcoding `America/New_York` via the third options arg keeps the wall-clock semantics matching the bot's US-holiday-oriented purpose and handles EST↔EDT transitions automatically.

## Changes

- `discord.js`: introduce a `cronOpts = { timezone: 'America/New_York' }` and pass it to both `cron.schedule` calls (and to the debug-only test cron for consistency).

## Test plan

- [ ] `node -c discord.js` passes (done locally — syntax OK)
- [ ] One-liner sanity: `TZ=UTC node -e "require('node-cron').schedule('* * * * *', () => console.log(new Date().toString()), {timezone:'America/New_York'})"` and confirm ticks log Eastern wall-clock time
- [ ] Boot the bot on a UTC host with a temporary `* * * * *` schedule and confirm it fires at the expected Eastern minute

## Conflicts

Touches `discord.js` at the same `cron.schedule(...)` lines as PR for #10, and the cron callback bodies as PR for #9. Small rebase expected based on merge order.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TDwMeQJJXAvLvtq7YWSJZm)_