### PR TITLE
Fix: guard steve trigger with null check before executing

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -116,10 +116,13 @@ client.on('message', message => {
    * STEVE ONLY
    ****************************************/
    if (message.author.id === process.env.STEVE_ID) {
-      try {
-         client.triggers.get('steve').execute(message, emojis);
-      } catch (error) {
-         console.log(error);
+      const steveTrigger = client.triggers.get('steve');
+      if (steveTrigger) {
+         try {
+            steveTrigger.execute(message, emojis);
+         } catch (error) {
+            console.log(error);
+         }
       }
    }
 


### PR DESCRIPTION
## Fix: guard steve trigger with null check before executing

Closes #14

**Problem:** `client.triggers.get('steve')` returns `undefined`. Calling `.execute()` on `undefined` throws:
```
TypeError: Cannot read properties of undefined (reading 'execute')
```
The `try/catch` swallows it but `console.log(error)` spams the exception on every Steve message.

**Fix:** Check if the steve trigger exists before calling execute:
```js
const steveTrigger = client.triggers.get('steve');
if (steveTrigger) {
  try {
    steveTrigger.execute(message, emojis);
  } catch (error) {
    console.log(error);
  }
}
```
